### PR TITLE
Ajustes visuais na página Explorar Pets

### DIFF
--- a/Views/Usuario/ExplorarPets.cshtml
+++ b/Views/Usuario/ExplorarPets.cshtml
@@ -352,7 +352,7 @@
                                     {
                                         <option value="12">12</option>
                                     }
-                                    
+
                                     @if (Model.ItensPorPaginaSelecionado == 24)
                                     {
                                         <option value="24" selected>24</option>
@@ -361,7 +361,16 @@
                                     {
                                         <option value="24">24</option>
                                     }
-                                    
+
+                                    @if (Model.ItensPorPaginaSelecionado == 36)
+                                    {
+                                        <option value="36" selected>36</option>
+                                    }
+                                    else
+                                    {
+                                        <option value="36">36</option>
+                                    }
+
                                     @if (Model.ItensPorPaginaSelecionado == 48)
                                     {
                                         <option value="48" selected>48</option>

--- a/wwwroot/css/usuario/usuario-explorar-pets.css
+++ b/wwwroot/css/usuario/usuario-explorar-pets.css
@@ -301,10 +301,10 @@ body {
 
 .pets-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(350px, 380px));
+    grid-template-columns: repeat(auto-fill, minmax(360px, 420px));
     gap: 2rem;
     width: 100%;
-    max-width: 1600px; 
+    max-width: 1800px;
     padding: 0 1.5rem;
     margin: 2rem auto;
     max-height: none;
@@ -329,7 +329,7 @@ body {
     width: 100%;
     margin: 0 auto;
     box-sizing: border-box;
-    max-width: 380px;
+    max-width: 420px;
 }
 
 
@@ -362,7 +362,7 @@ body {
 .image-container {
     position: relative;
     overflow: hidden;
-    height: 160px;
+    height: 200px;
     border-radius: 12px 12px 0 0;
     border-bottom: 2px solid rgba(255, 107, 107, 0.4);
 }
@@ -513,7 +513,7 @@ body {
 .pet-characteristics {
     display: grid;
     grid-template-columns: repeat(2, 1fr);
-    gap: 16px;
+    gap: 20px;
     margin: 20px 0;
     width: 100%;
     box-sizing: border-box;
@@ -1675,9 +1675,21 @@ body.modal-aberto {
 
 @media (min-width: 1601px) {
     .pets-container .pets-grid {
-        
-        grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
-        gap: 2rem; 
+        grid-template-columns: repeat(auto-fill, minmax(360px, 420px));
+        gap: 2rem;
+    }
+}
+
+@media (min-width: 1920px) {
+    .pets-container .pets-grid {
+        max-width: 2000px;
+        grid-template-columns: repeat(auto-fill, minmax(420px, 1fr));
+    }
+}
+
+@media (min-width: 2560px) {
+    .pets-container .pets-grid {
+        max-width: 2400px;
     }
 }
 


### PR DESCRIPTION
## Resumo
Ampliar os cards de pets para evitar informação comprimida
Oferecer uma nova opção de 36 cards por página
Dar suporte a telas largas, incluindo ultrawide