### PR TITLE
Melhora layout e responsividade da listagem de pets

### DIFF
--- a/wwwroot/css/usuario/usuario-explorar-pets.css
+++ b/wwwroot/css/usuario/usuario-explorar-pets.css
@@ -301,10 +301,10 @@ body {
 
 .pets-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(350px, 380px));
+    grid-template-columns: repeat(auto-fill, minmax(360px, 1fr));
     gap: 2rem;
     width: 100%;
-    max-width: 1600px; 
+    max-width: 1600px;
     padding: 0 1.5rem;
     margin: 2rem auto;
     max-height: none;
@@ -329,7 +329,7 @@ body {
     width: 100%;
     margin: 0 auto;
     box-sizing: border-box;
-    max-width: 380px;
+    max-width: 420px;
 }
 
 
@@ -512,9 +512,9 @@ body {
 
 .pet-characteristics {
     display: grid;
-    grid-template-columns: repeat(2, 1fr);
-    gap: 16px;
-    margin: 20px 0;
+    grid-template-columns: repeat(auto-fit, minmax(170px, 1fr));
+    gap: 1.5rem;
+    margin: 1.5rem 0;
     width: 100%;
     box-sizing: border-box;
 }
@@ -1673,11 +1673,16 @@ body.modal-aberto {
 }
 
 
-@media (min-width: 1601px) {
+@media (min-width: 1920px) {
     .pets-container .pets-grid {
-        
-        grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
-        gap: 2rem; 
+        grid-template-columns: repeat(auto-fill, minmax(380px, 1fr));
+        gap: 2rem;
+    }
+}
+
+@media (min-width: 2560px) {
+    .pets-container .pets-grid {
+        grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
     }
 }
 
@@ -1852,10 +1857,9 @@ body.modal-aberto {
 }
 
 
-@media (min-width: 1400px) {
+@media (min-width: 1600px) {
     .pets-container .pets-grid {
-        
-        grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+        grid-template-columns: repeat(auto-fill, minmax(360px, 1fr));
         max-width: 100%;
         margin: 0 auto;
     }

--- a/wwwroot/js/usuario/explorar-pets.js
+++ b/wwwroot/js/usuario/explorar-pets.js
@@ -1088,16 +1088,16 @@ function obterCardsPorLinha() {
         
         
         
-        if (window.innerWidth <= 576) {
-            return 1; 
-        } else if (window.innerWidth <= 768) {
-            return 2; 
-        } else if (window.innerWidth <= 1200) {
-            return 3; 
-        } else if (window.innerWidth <= 1600) {
-            return 4; 
+        if (window.innerWidth <= 992) {
+            return 2;
+        } else if (window.innerWidth <= 1366) {
+            return 3;
+        } else if (window.innerWidth <= 1920) {
+            return 4;
+        } else if (window.innerWidth <= 2560) {
+            return 5;
         } else {
-            return 5; 
+            return 6;
         }
     }
     
@@ -1140,16 +1140,16 @@ function obterCardsPorLinha() {
             }
             
             
-            if (window.innerWidth <= 576) {
-                return 1;
-            } else if (window.innerWidth <= 768) {
+            if (window.innerWidth <= 992) {
                 return 2;
-            } else if (window.innerWidth <= 1200) {
+            } else if (window.innerWidth <= 1366) {
                 return 3;
-            } else if (window.innerWidth <= 1600) {
+            } else if (window.innerWidth <= 1920) {
                 return 4;
-            } else {
+            } else if (window.innerWidth <= 2560) {
                 return 5;
+            } else {
+                return 6;
             }
         }
         
@@ -1158,16 +1158,16 @@ function obterCardsPorLinha() {
         console.error("Erro ao calcular colunas do grid:", e);
         
         
-        if (window.innerWidth <= 576) {
-            return 1;
-        } else if (window.innerWidth <= 768) {
+        if (window.innerWidth <= 992) {
             return 2;
-        } else if (window.innerWidth <= 1200) {
+        } else if (window.innerWidth <= 1366) {
             return 3;
-        } else if (window.innerWidth <= 1600) {
+        } else if (window.innerWidth <= 1920) {
             return 4;
-        } else {
+        } else if (window.innerWidth <= 2560) {
             return 5;
+        } else {
+            return 6;
         }
     }
 }


### PR DESCRIPTION
## Resumo
- amplia largura dos cards na tela de explorar pets
- reorganiza características do pet dentro dos cards
- adiciona breakpoints para telas 16:9 e ultrawide
- ajusta cálculo de colunas no JavaScript

## Testes
- `dotnet build` *(falhou: comando indisponível)*
- `npm test` *(falhou: package.json ausente)*

------
https://chatgpt.com/codex/tasks/task_e_68535d7573208325b444dccb3bdca7f7